### PR TITLE
better category/tags matching

### DIFF
--- a/src/client/components/PackageForm.tsx
+++ b/src/client/components/PackageForm.tsx
@@ -10,7 +10,7 @@ import {
   FormChangeEvent,
   FormError,
 } from "client/types/FormProvider";
-import { get, isEmpty, pick } from "lodash/fp";
+import { isEmpty, pick } from "lodash/fp";
 import ErrorComponent from "./ErrorComponent";
 import useLocation from "client/helpers/useLocation";
 import ImageField from "./ImageField";
@@ -95,6 +95,13 @@ export default function PackageForm(props: PackageFormProps) {
   const handleFormSubmit = async (e: SyntheticEvent) => {
     e.preventDefault();
     const data = pickFields(inputs) as PackageData;
+
+    // @TODO temporary until the tokenizer is done
+    // trim the white space around each tag
+    data.tags = data.tags
+      .split(",")
+      .map(t => t.trim())
+      .join(",");
 
     try {
       if (inputs.image) {

--- a/src/server/routes/api/v1/packages/index.js
+++ b/src/server/routes/api/v1/packages/index.js
@@ -6,7 +6,9 @@ import { parseError } from "server/helpers/parseError";
 import { packageSchema } from "server/helpers/validatorSchemas";
 
 const addCategory = (query, category) =>
-  query.andWhere({ category }).orWhere("tags", "like", `%${category}%`);
+  query.andWhere(whereCtx => {
+    whereCtx.where({ category }).orWhereRaw(`find_in_set('${category}', tags)`);
+  });
 
 exports.get = [
   checkUser({ required: false }),


### PR DESCRIPTION
This updates the query to use set matching for looking for the category in the list of tags.

Also means there can't be any white space after `,`s in the tags list.

Once the tokenizer is in place the tag list won't be directly visible to the users so it'll be easier to keep it in the format we want.

fixes #58 